### PR TITLE
Fix to PR#8

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,30 +4,29 @@
 
 There are four files required by this parser:
 
-1. The _PREDICATION_ CSV file. 
-    - Version: `semmedVER43_R`
-    - Download page: https://lhncbc.nlm.nih.gov/ii/tools/SemRep_SemMedDB_SKR/SemMedDB_download.html
-    - Direct download link: https://data.lhncbc.nlm.nih.gov/umls-restricted/ii/tools/SemRep_SemMedDB_SKR/semmedVER43_2022_R_PREDICATION.csv.gz
-    - Filename: `semmedVER43_2022_R_PREDICATION.csv.gz`
-2. The _Semantic Type Mappings_ file.
-    - Version: `2018AB` (UMLS release version number, as shown in [UMLS Release File Archives](https://www.nlm.nih.gov/research/umls/licensedcontent/umlsarchives04.html))
-    - Download page: https://lhncbc.nlm.nih.gov/ii/tools/MetaMap/documentation/SemanticTypesAndGroups.html
-    - Direct download link: https://lhncbc.nlm.nih.gov/ii/tools/MetaMap/Docs/SemanticTypes_2018AB.txt
-    - Filenname: `SemanticTypes_2018AB.txt`
-3. The _Retired CUI Mapping_ file.
-    - Version: `2022AA` (UMLS release version number, as shown in [UMLS Release File Archives](https://www.nlm.nih.gov/research/umls/licensedcontent/umlsarchives04.html))
-    - Download page: this file is part of the [_2022AA UMLS Metathesaurus Full Subset_](https://www.nlm.nih.gov/research/umls/licensedcontent/umlsarchives04.html); no direct download link is available.
-    - Description: https://www.ncbi.nlm.nih.gov/books/NBK9685/table/ch03.T.retired_cui_mapping_file_mrcui_rr/
-    - Filename: `MRCUI.RRF`
-4. The _Preferred CUI Names & Semtypes_ file.
+1. `semmedVER43_2022_R_PREDICATION.csv.gz`, the _PREDICATION_ CSV file
+    - Version: `43`
+    - [Download page](https://lhncbc.nlm.nih.gov/ii/tools/SemRep_SemMedDB_SKR/SemMedDB_download.html) (**UMLS login required**)
+2. `SemanticTypes_2018AB.txt`, the _Semantic Type Mappings_ file
+    - Version: `2018AB`
+    - [Download page](https://lhncbc.nlm.nih.gov/ii/tools/MetaMap/documentation/SemanticTypesAndGroups.html) (**UMLS login required**)
+3. `MRCUI.RRF`, the _Retired CUI Mapping_ file
+    - Version: `2022AA`
+    - Download page: this file is part of the [2022AA UMLS Metathesaurus Full Subset](https://www.nlm.nih.gov/research/umls/licensedcontent/umlsarchives04.html) (**UMLS login required**); no direct download link is available.
+    - [Description page](https://www.ncbi.nlm.nih.gov/books/NBK9685/table/ch03.T.retired_cui_mapping_file_mrcui_rr/)
+4. `UMLS_CUI_Semtype.tsv`, the _Preferred CUI Names & Semtypes_ file.
     - Github Repo: https://github.com/erikyao/UMLS_CUI_Semtype
     - How to Generate:
         - Source data files:
-            - The _Retired CUI Mapping_ file, `MRCUI.RRF` (see above).
-            - The _Concept Names and Sources_ file, `MRCONSO.RRF`.
+            1. `MRCUI.RRF` (see above)
+            2. `MRCONSO.RRF`, the _Concept Names and Sources_ file
                 - Version: `2022AA`
-                - Download page: https://www.nlm.nih.gov/research/umls/licensedcontent/umlsarchives04.html
-                - Description: https://www.ncbi.nlm.nih.gov/books/NBK9685/table/ch03.T.concept_names_and_sources_file_mr/
-            - The _Semantic Type Mappings_ file, `SemanticTypes_2018AB.txt` (see above).
+                - [Download page](https://www.nlm.nih.gov/research/umls/licensedcontent/umlsarchives04.html) (**UMLS login required**)
+                - [Description page](https://www.ncbi.nlm.nih.gov/books/NBK9685/table/ch03.T.concept_names_and_sources_file_mr/)
+            3. `MRSTY.RRF`, the _Semantic Types_ file
+                - Version: `2022AA`
+                - Download page: this file is part of the [2022AA UMLS Metathesaurus Full Subset](https://www.nlm.nih.gov/research/umls/licensedcontent/umlsarchives04.html) (**UMLS login required**); no direct download link is available.
+                - [Description page](https://www.ncbi.nlm.nih.gov/books/NBK9685/table/ch03.Tf/)
+            4. `SemanticTypes_2018AB.txt` (see above)
         - Script: [parser.py](https://github.com/erikyao/UMLS_CUI_Semtype/blob/main/parser.py)
-    - Filename: `UMLS_CUI_Semtype.tsv`, as shown [here](https://github.com/erikyao/UMLS_CUI_Semtype/blob/main/parser.py#L188)
+            - Filename is as hardcoded [here](https://github.com/erikyao/UMLS_CUI_Semtype/blob/main/parser.py#L188).

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ There are four files required by this parser:
     - [Download page](https://lhncbc.nlm.nih.gov/ii/tools/SemRep_SemMedDB_SKR/SemMedDB_download.html) (**UMLS login required**)
 2. `SemanticTypes_2018AB.txt`, the _Semantic Type Mappings_ file
     - Version: `2018AB`
-    - [Download page](https://lhncbc.nlm.nih.gov/ii/tools/MetaMap/documentation/SemanticTypesAndGroups.html) (**UMLS login required**)
+    - [Download page](https://lhncbc.nlm.nih.gov/ii/tools/MetaMap/documentation/SemanticTypesAndGroups.html)
 3. `MRCUI.RRF`, the _Retired CUI Mapping_ file
     - Version: `2022AA`
     - Download page: this file is part of the [2022AA UMLS Metathesaurus Full Subset](https://www.nlm.nih.gov/research/umls/licensedcontent/umlsarchives04.html) (**UMLS login required**); no direct download link is available.

--- a/manifest.json
+++ b/manifest.json
@@ -10,6 +10,7 @@
             "http://localhost:8080/dataupload/mysrc/semmeddb/semmedVER43_2022_R_PREDICATION.csv",
             "http://localhost:8080/dataupload/mysrc/semmeddb/MRCUI.RRF",
             "http://localhost:8080/dataupload/mysrc/semmeddb/UMLS_CUI_Semtype.tsv",
+            "http://localhost:8080/dataupload/mysrc/semmeddb/semmedVER43_2022_R_PREDICATION_NodeNorm.pickle",
             "https://lhncbc.nlm.nih.gov/ii/tools/MetaMap/Docs/SemanticTypes_2018AB.txt"
         ],
         "uncompress" : false,

--- a/manifest.json
+++ b/manifest.json
@@ -7,12 +7,12 @@
     },
     "dumper" : {
         "data_url" : [
-            "https://data.lhncbc.nlm.nih.gov/umls-restricted/ii/tools/SemRep_SemMedDB_SKR/semmedVER43_2022_R_PREDICATION.csv.gz",
-            "https://lhncbc.nlm.nih.gov/ii/tools/MetaMap/Docs/SemanticTypes_2018AB.txt",
+            "http://localhost:8080/dataupload/mysrc/semmeddb/semmedVER43_2022_R_PREDICATION.csv",
             "http://localhost:8080/dataupload/mysrc/semmeddb/MRCUI.RRF",
-            "http://localhost:8080/dataupload/mysrc/semmeddb/UMLS_CUI_Semtype.tsv"
+            "http://localhost:8080/dataupload/mysrc/semmeddb/UMLS_CUI_Semtype.tsv",
+            "https://lhncbc.nlm.nih.gov/ii/tools/MetaMap/Docs/SemanticTypes_2018AB.txt"
         ],
-        "uncompress" : true,
+        "uncompress" : false,
         "release" : "version:get_release"
     },
     "uploader" : {


### PR DESCRIPTION
This PR fixes two issues in the previous PR https://github.com/biothings/semmeddb/pull/8:

- Hub cannot download the SemMedDB predication CSV file because UMLS login is required for downloads. We've manually uploaded the file to the server and changed its dumper link to the "dataupload" folder.
- The main parser function cannot be `async` so the previous implementation in `aiohttp` cannot work. We've revised it to the vanilla implementation in `requests`. To save the running time, a pickled response is used to bypass the queries.